### PR TITLE
Fix pastebin (again)

### DIFF
--- a/faqs/pastebin-pre1.8.md
+++ b/faqs/pastebin-pre1.8.md
@@ -4,8 +4,9 @@ Pastebin changed the way files are downloaded a few years ago. This means that o
 
 Here are two methods you can use to fix the `pastebin` program and make it work on old versions of ComputerCraft.
 
-**Using a resource pack (MC 1.6.1 - 1.7.10)** 
-This method fixes the program for all computers (in all worlds on singleplayer), but it requires the server owner to install a resource pack if used for a server. Simply download [this resource pack](https://www.mediafire.com/download/1g4d4oon6zaf6po/CC+Pastebin+Fix.zip) and install it into your `resourcepacks` folder, or into the server's installation directory. Then restart Minecraft and apply the resource pack. After that, the default `pastebin` program should function normally.
+**Using a resource pack (MC 1.6.1 - 1.7.10)**
+
+This method fixes the program for all computers (in all worlds on singleplayer), but it requires the server owner to install a resource pack if used for a server. Simply download [this resource pack](https://drive.google.com/file/d/1syLH68L5ToH8GU32SCnyKu_FpS38OJ4G/view?usp=sharing) and install it into your `resourcepacks` folder, or into the server's installation directory. Then restart Minecraft and apply the resource pack. After that, the default `pastebin` program should function normally.
 
 **Manually patching the program**
 This method only fixes the program on one computer, and must be run for each computer that needs to be patched, but it doesn't require modifying Minecraft in any way, and works fine on servers. First, copy the default `pastebin` program to the root directory of your computer, and then edit it with these commands:
@@ -15,11 +16,11 @@ edit /pastebin
 ```
 Then go to line 24, and replace this:
 ```
-"http://pastebin.com/raw.php?i="..textutils.urlEncode( paste )
+"https://pastebin.com/raw.php?i="..textutils.urlEncode( paste )
 ```
 with this:
 ```
-"http://pastebin.com/raw/"..textutils.urlEncode( paste )
+"https://pastebin.com/raw/"..textutils.urlEncode( paste )
 ```
 After that, you can run the pastebin program at `/pastebin`.
 

--- a/faqs/pastebin-pre1.8.md
+++ b/faqs/pastebin-pre1.8.md
@@ -15,7 +15,7 @@ edit /pastebin
 ```
 Then go to line 24, and replace this:
 ```
-"https://pastebin.com/raw.php?i="..textutils.urlEncode( paste )
+"http://pastebin.com/raw.php?i="..textutils.urlEncode( paste )
 ```
 with this:
 ```

--- a/faqs/pastebin-pre1.8.md
+++ b/faqs/pastebin-pre1.8.md
@@ -5,7 +5,6 @@ Pastebin changed the way files are downloaded a few years ago. This means that o
 Here are two methods you can use to fix the `pastebin` program and make it work on old versions of ComputerCraft.
 
 **Using a resource pack (MC 1.6.1 - 1.7.10)**
-
 This method fixes the program for all computers (in all worlds on singleplayer), but it requires the server owner to install a resource pack if used for a server. Simply download [this resource pack](https://drive.google.com/file/d/1syLH68L5ToH8GU32SCnyKu_FpS38OJ4G/view?usp=sharing) and install it into your `resourcepacks` folder, or into the server's installation directory. Then restart Minecraft and apply the resource pack. After that, the default `pastebin` program should function normally.
 
 **Manually patching the program**

--- a/faqs/too_long_without_yielding.md
+++ b/faqs/too_long_without_yielding.md
@@ -1,0 +1,21 @@
+** Too Long Without Yielding **
+
+Computercraft has a builtin system which stops a single computer from running for too long at a time. After ~7 seconds of nonstop running, your computer will receive an error, `Too long without yielding`.
+
+If, a few seconds after your program received the initial error, your program still has not yielded (ie: the error was caught by `pcall` or `xpcall`), the computer itself will shut down.
+
+** How do I fix this? **
+
+First, you need to figure out where your program is looping. The error itself may not be too helpful, as the `Too long without yielding `error points to the last line that was run before timing out (which could be OS code, or some other library's code). In most cases, you're looking for a `while true do` loop.
+
+Once you find where it's looping forever, you can simply add `sleep()` or `os.sleep()`. In most cases this will fix the problem.
+
+Ex:
+
+```lua
+while true do
+  -- Your code here
+  ...
+  sleep()
+end
+```


### PR DESCRIPTION
Pastebin stopped supporting `http`, so our fix no longer worked. Fixed it in this version here.