### PR TITLE
Make bot react with :wastebasket: on eval messages.

### DIFF
--- a/ccfaq/commands/eval.py
+++ b/ccfaq/commands/eval.py
@@ -117,11 +117,13 @@ class EvalCog(commands.Cog):
         if not image:
             await ctx.reply(":bangbang: No screenshot returned. Sorry!", mention_author=False)
         else:
-            await ctx.reply(
+            message = await ctx.reply(
                 "\n".join(warnings),
                 mention_author=False,
                 file=discord.File(io.BytesIO(image), 'image.png')
             )
+            # Add the :wastebasket: reaction to these messages.
+            message.add_reaction("\U0001f5d1\U0000fe0f")
 
 
     def cog_unload(self) -> None:


### PR DESCRIPTION
People on MCCM have requested that the bot react with :wastebasket: on the eval messages, for "easy deletion of the messages".
This is a simple change, only requiring to catch the output of `ctx.send` (Which returns a message object) and call `message.add_reaction` on it, adding the reaction. This should not trigger the deletion, as the `user` of the `on_reaction_add` will be the bot, instead of the reference author.