### PR TITLE
Right-strip `()` from docs and source commands, and remove extra '

### DIFF
--- a/ccfaq/commands/docs.py
+++ b/ccfaq/commands/docs.py
@@ -57,7 +57,7 @@ class DocsCog(commands.Cog):
         """Search the documentation with a query and link to the result"""
         methods = await self.methods.get()
 
-        search_k = search.lower()
+        search_k = search.lower().rstrip("()")
         if search_k in methods:
             LOG.info(f'event=search search="{search}"')
             await ctx.send(embeds=[_embed(methods[search_k], link)])
@@ -79,7 +79,7 @@ class DocsCog(commands.Cog):
             method = methods[best_match]
             LOG.info(f'event=search.approx search="{search}" result="{method["original_name"]}"')
             await ctx.send(
-                content=f"Cannot find '{search}', using '{method['original_name']}'' instead.",
+                content=f"Cannot find '{search}', using '{method['original_name']}' instead.",
                 embeds=[_embed(method, link)],
             )
             return


### PR DESCRIPTION
This isn't exactly a mission-critical change, but when someone does
`%d drive.hasAudio()`
it responds with
`Cannot find 'drive.hasAudio()', using 'drive.hasAudio'' instead.`
This change fixes that by removing `()` from the end of the strings, letting it only send the embed.

The other change in this commit is removing an extra `'` in the `Cannot find '<blank>', using '<blank>' instead.` warning.