### PR TITLE
Add missing string functions to docs

### DIFF
--- a/src/LuaNames.fs
+++ b/src/LuaNames.fs
@@ -152,6 +152,9 @@ let private lua53Vars =
      "bit32.replace"
      "bit32.rrotate"
      "bit32.rshift"
+     "string.pack"
+     "string.packsize"
+     "string.unpack"
      "table.pack"
      "table.unpack" |]
 


### PR DESCRIPTION
The docs command is missing the `pack`, `unpack`, and `packsize` for Lua 5.3
https://i.skystuff.cc/PEUlSF5te0AR.png