### PR TITLE
Replace wiki links with tweaked.cc links in local IP FAQ

### DIFF
--- a/faqs/local_ips.md
+++ b/faqs/local_ips.md
@@ -4,6 +4,6 @@ search: local ips
 ---
 By default, ComputerCraft blocks access to local IP addresses for security. This means you can't normally access any HTTP server running on your computer. However, this may be useful for testing programs without having a remote server. You can unblock these IPs in the ComputerCraft config.
 
- - [Minecraft 1.13+, CC: Tweaked 1.87 and later](https://github.com/cc-tweaked/CC-Tweaked/wiki/Allowing-access-to-local-IPs#minecraft-113-and-later-cct-1870-and-later)
- - [Minecraft 1.13+, CC: Tweaked 1.86.2 and earlier](https://github.com/cc-tweaked/CC-Tweaked/wiki/Allowing-access-to-local-IPs#minecraft-113-and-later-cct-1862-and-earlier)
- - [Minecraft 1.12 and earlier](https://github.com/cc-tweaked/CC-Tweaked/wiki/Allowing-access-to-local-IPs#minecraft-1122-and-earlier)
+ - [Minecraft 1.13+, CC: Tweaked 1.87 and later](https://tweaked.cc/guide/local_ips.html#cc-1.87.0)
+ - [Minecraft 1.13+, CC: Tweaked 1.86.2 and earlier](https://tweaked.cc/guide/local_ips.html#cc-1.86.2)
+ - [Minecraft 1.12 and earlier](https://tweaked.cc/guide/local_ips.html#mc-1.12)


### PR DESCRIPTION
The pages for accessing local IPs have been moved to tweaked.cc. I kept the version links separate and used the equivalent anchor links to the tweaked.cc page.