### PR TITLE
docs: optifine compatibility FAQ

### DIFF
--- a/faqs/optifine.md
+++ b/faqs/optifine.md
@@ -4,24 +4,6 @@ search: optifine
 ---
 OptiFine is known to be [incompatible with many mods, including CC: Tweaked](<https://github.com/sp614x/optifine/issues/7395>). If you are experiencing problems with peripherals not connecting, and you have OptiFine installed, you will need to remove OptiFine.
 
-There are many replacement mods available for OptiFine's functionality. You don't need all of these—you can pick just the ones you need.
+For performance improvements, we recommend **[Sodium](<https://modrinth.com/mod/sodium>)** (NeoForge/Fabric) or **[Embeddium](<https://modrinth.com/mod/embeddium>)** (Forge). For shaders, [Iris](<https://modrinth.com/mod/iris>) (NeoForge/Fabric) or [Oculus](<https://modrinth.com/mod/oculus>) (Forge) are recommended.
 
-### Forge/NeoForge
-- **[Embeddium](<https://modrinth.com/mod/embeddium/versions>): performance improvements**
-- [Oculus](<https://modrinth.com/mod/oculus>): shaders
-- [Fusion](<https://modrinth.com/mod/fusion-connected-textures>): connected textures
-- [ETF](<https://modrinth.com/mod/entitytexturefeatures>): advanced resource pack texture features
-- [EMF](<https://modrinth.com/mod/entity-model-features>): custom entity models
-- [RyoamicLights](<https://modrinth.com/mod/ryoamiclights>): dynamic lights
-
-### Fabric/Quilt
-- **[Sodium](<https://modrinth.com/mod/sodium>): performance improvements**
-- **[Indium](<https://modrinth.com/mod/indium>): mod compatibility, required with Sodium**
-- [Sodium Extra](<https://modrinth.com/mod/sodium-extra>): more settings for Sodium
-- [Iris](<https://modrinth.com/mod/iris>): shaders
-- [Continuity](<https://modrinth.com/mod/continuity>): connected textures
-- [Animatica](<https://modrinth.com/mod/animatica>): advanced resource pack texture features
-- [CEM](<https://modrinth.com/mod/cem>): custom entity models
-- [LambDynamicLights](<https://modrinth.com/mod/lambdynamiclights>): dynamic lights
-
-View the full list of alternatives [here](<https://optifine.alternatives.lambdaurora.dev/>).
+For OptiFine's other features, view the full list of alternatives [here](<https://optifine.alternatives.lambdaurora.dev/>).

--- a/faqs/optifine.md
+++ b/faqs/optifine.md
@@ -1,0 +1,27 @@
+---
+title: Optifine Compatibility
+search: optifine
+---
+Optifine is known to be [incompatible with many mods, including CC: Tweaked](<https://github.com/sp614x/optifine/issues/7395>). If you are experiencing problems with peripherals not connecting, and you have Optifine installed, you will need to remove Optifine.
+
+There are many replacement mods available for Optifine's functionality. You don't need all of these—you can pick just the ones you need.
+
+### Forge/NeoForge
+- **[Embeddium](<https://modrinth.com/mod/embeddium/versions>): performance improvements**
+- [Oculus](<https://modrinth.com/mod/oculus>): shaders
+- [Fusion](<https://modrinth.com/mod/fusion-connected-textures>): connected textures
+- [ETF](<https://modrinth.com/mod/entitytexturefeatures>): advanced resource pack texture features
+- [EMF](<https://modrinth.com/mod/entity-model-features>): custom entity models
+- [RyoamicLights](<https://modrinth.com/mod/ryoamiclights>): dynamic lights
+
+### Fabric/Quilt
+- **[Sodium](<https://modrinth.com/mod/sodium>): performance improvements**
+- **[Indium](<https://modrinth.com/mod/indium>): mod compatibility, required with Sodium**
+- [Sodium Extra](<https://modrinth.com/mod/sodium-extra>): more settings for Sodium
+- [Iris](<https://modrinth.com/mod/iris>): shaders
+- [Continuity](<https://modrinth.com/mod/continuity>): connected textures
+- [Animatica](<https://modrinth.com/mod/animatica>): advanced resource pack texture features
+- [CEM](<https://modrinth.com/mod/cem>): custom entity models
+- [LambDynamicLights](<https://modrinth.com/mod/lambdynamiclights>): dynamic lights
+
+View the full list of alternatives [here](<https://optifine.alternatives.lambdaurora.dev/>).

--- a/faqs/optifine.md
+++ b/faqs/optifine.md
@@ -1,10 +1,10 @@
 ---
-title: Optifine Compatibility
+title: OptiFine Compatibility
 search: optifine
 ---
-Optifine is known to be [incompatible with many mods, including CC: Tweaked](<https://github.com/sp614x/optifine/issues/7395>). If you are experiencing problems with peripherals not connecting, and you have Optifine installed, you will need to remove Optifine.
+OptiFine is known to be [incompatible with many mods, including CC: Tweaked](<https://github.com/sp614x/optifine/issues/7395>). If you are experiencing problems with peripherals not connecting, and you have OptiFine installed, you will need to remove OptiFine.
 
-There are many replacement mods available for Optifine's functionality. You don't need all of these—you can pick just the ones you need.
+There are many replacement mods available for OptiFine's functionality. You don't need all of these—you can pick just the ones you need.
 
 ### Forge/NeoForge
 - **[Embeddium](<https://modrinth.com/mod/embeddium/versions>): performance improvements**


### PR DESCRIPTION
Adds an FAQ entry noting OptiFine's incompatibility with CC: Tweaked, and provides quick links to replacement mods for the most commonly used OptiFine features, as a quick reference for people who might think they need OptiFine specifically for one reason or another.

The Fabric links are provided mainly as a courtesy, even though the incompatibilities (as far as I'm aware) are only with Forge.